### PR TITLE
chore(release): cut 0.1.3 to publish merged shebang fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.3] - Unreleased
+
+### Fixed
+
+- Ship the `#!/usr/bin/env node` shebang in the published `dist/index.js` so the
+  npm-installed `bin` shim is executed by Node, not by the parent shell. Without
+  this, MCP clients that launch the server via `npx -y reclaim-mcp-server` fail
+  immediately with errors like `import: command not found` and
+  `syntax error near unexpected token '('` because the shell tries to parse the
+  JavaScript file as a shell script. The shebang was added to the source tree
+  by @sempostma in [`f356dce`](https://github.com/johnjhughes/reclaim-mcp-server/commit/f356dce1e0fef125eef249fcfa8430391087ea6e)
+  but never made it into a published release.
+
+## [0.1.2] - 2025-04-21
+
+Initial published release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reclaim-mcp-server",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A Model Context Protocol (MCP) server for interacting with Reclaim.ai tasks.",
   "main": "./dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Bumps version to **0.1.3** so the already-merged shebang fix can be published to npm. No code change beyond the version bump and a new `CHANGELOG.md`.

## The bug in 0.1.2

The published `0.1.2` tarball ships `dist/index.js` without a `#!/usr/bin/env node` shebang. Because `package.json` declares that file as the package's `bin`, npm symlinks it into `node_modules/.bin/reclaim-mcp-server` and the OS hands it to the parent shell — not Node — when invoked. The shell tries to interpret JavaScript and dies:

```
.../node_modules/.bin/reclaim-mcp-server: line 1: /Applications: is a directory
.../node_modules/.bin/reclaim-mcp-server: line 5: import: command not found
.../node_modules/.bin/reclaim-mcp-server: line 14: syntax error near unexpected token '('
```

This breaks every MCP client that launches the server via the canonical `npx -y reclaim-mcp-server` invocation (Claude Code, Cursor, Claude Desktop). End users see the server stuck in `Failed to connect`.

## Why no code change is needed

@sempostma already added the shebang to `src/index.ts` in [`f356dce`](https://github.com/johnjhughes/reclaim-mcp-server/commit/f356dce1e0fef125eef249fcfa8430391087ea6e) (Aug 2025) — four months after `0.1.2` was published. TypeScript ≥5.0 preserves leading shebangs, so `tsc` on current `main` already produces a correctly-shebanged `dist/index.js`. The fix just needs a release.

## Test plan

Anyone can verify pre-merge by building from this branch:

- [ ] `git fetch origin pull/2/head:pr-2 && git checkout pr-2`
- [ ] `npm install --legacy-peer-deps && npx tsc`
- [ ] `head -1 dist/index.js` → prints `#!/usr/bin/env node`
- [ ] `file dist/index.js` → reports `script text executable`
- [ ] `RECLAIM_API_KEY=<key> node dist/index.js </dev/null` → prints `✅ reclaim-mcp-server is running and connected via stdio.`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue preventing the CLI tool from running correctly when invoked via `npx`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->