### PR TITLE
docs(readme): mention Reclaim's official remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 # Reclaim.ai MCP Server 🚀 _(UNOFFICIAL)_
 
 > **⚠️ UNOFFICIAL & UNAFFILIATED** – This project is **not** endorsed, sponsored, or supported by Reclaim.ai. It simply uses Reclaim's public API. Use at your own risk and comply with Reclaim's Terms of Service.
+>
+> **Official alternative:** Reclaim.ai offers an official remote MCP server at `https://api.app.reclaim.ai/api/mcp` (currently waitlisted). If you have access, you may prefer it over this community server. See [#3](https://github.com/johnjhughes/reclaim-mcp-server/issues/3).
 
 A community‑maintained [**Model Context Protocol**](https://modelcontextprotocol.io/) (MCP) server that lets _any_ MCP‑capable client (Claude Desktop, Continue, Cursor, custom scripts, …) interact with the [Reclaim.ai API](https://reclaim.ai/) through a set of standard **resources** & **tools**.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 > **⚠️ UNOFFICIAL & UNAFFILIATED** – This project is **not** endorsed, sponsored, or supported by Reclaim.ai. It simply uses Reclaim's public API. Use at your own risk and comply with Reclaim's Terms of Service.
 >
-> **Official alternative:** Reclaim.ai offers an official remote MCP server at `https://api.app.reclaim.ai/api/mcp` (currently waitlisted). If you have access, you may prefer it over this community server. See [#3](https://github.com/johnjhughes/reclaim-mcp-server/issues/3).
+> **Official alternative:** Reclaim.ai offers an official remote MCP server at `https://mcp.reclaim.ai`. You may prefer the first-party integration over this community server. See [Reclaim's setup instructions](https://reclaim.ai/integrations/claude) and [#3](https://github.com/johnjhughes/reclaim-mcp-server/issues/3).
 
 A community‑maintained [**Model Context Protocol**](https://modelcontextprotocol.io/) (MCP) server that lets _any_ MCP‑capable client (Claude Desktop, Continue, Cursor, custom scripts, …) interact with the [Reclaim.ai API](https://reclaim.ai/) through a set of standard **resources** & **tools**.
 


### PR DESCRIPTION
## Summary

Updates the README disclosure for Reclaim official remote MCP server to use the current endpoint, https://mcp.reclaim.ai, and links the official setup instructions.

Issue #3 is already closed as completed now that the first-party integration is available.

## Test plan

- Docs-only change.
- Verified the endpoint against the official Reclaim Claude integration page.
- Reviewed the rendered Markdown diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an “Official alternative” callout after the existing UNOFFICIAL disclaimer, pointing to Reclaim.ai’s first-party remote MCP server (`https://mcp.reclaim.ai`) with setup guidance.
  * Linked to a related issue and referenced the current waitlist status for availability.
  * Kept the License section consistent (“MIT – see LICENSE.”)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->