### PR TITLE
chore: pin pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,5 +91,6 @@
         }
       }
     }
-  }
+  },
+  "packageManager": "pnpm@10.19.0+sha512.c9fc7236e92adf5c8af42fd5bf1612df99c2ceb62f27047032f4720b33f8eacdde311865e91c411f2774f618d82f320808ecb51718bfa82c060c4ba7c76a32b8"
 }


### PR DESCRIPTION
## Summary

Pins pnpm 10.19.0 in package.json so Corepack uses the repository-tested package manager consistently.

This preserves the existing local package-manager change and the equivalent historical stash/autostash intent.

## Validation

- corepack pnpm@10.19.0 --version
- corepack pnpm@10.19.0 typecheck
- corepack pnpm@10.19.0 build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only change with no runtime, auth, or application logic impact.
> 
> **Overview**
> Adds a **`packageManager`** field to `package.json` pinning **pnpm 10.19.0** (with Corepack integrity hash) so installs and CI use the same package manager version the repo was tested with.
> 
> Also fixes the root JSON structure by properly closing the **`mcp`** block before the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4e1d0aa3867902ca13f037d35d579b55eeb4841. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added project-level package manager metadata, including the pnpm version and integrity hash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->